### PR TITLE
fix build with --disable-ssl

### DIFF
--- a/libhttp/ssl.c
+++ b/libhttp/ssl.c
@@ -590,7 +590,6 @@ static int sslSetCertificateFromFile(SSL_CTX *context,
   int rc = sslSetCertificateFromFd(context, fd);
   return rc;
 }
-#endif
 
 static SSL_CTX *sslMakeContext(void) {
   SSL_CTX *context;
@@ -617,6 +616,7 @@ static SSL_CTX *sslMakeContext(void) {
   check(SSL_CTX_set_cipher_list(context, "HIGH:MEDIUM:!aNULL:!MD5"));
   return context;
 }
+#endif
 
 #ifdef HAVE_TLSEXT
 static int sslSNICallback(SSL *sslHndl, int *al ATTR_UNUSED,


### PR DESCRIPTION
Commit b06b1f15aca3e42710ed6a496624e649464e2281 broke the configure option
"--disable-ssl" as the function sslMakeContext() was not enclosed in an
"#if defined(HAVE_OPENSSL)" statement.