### PR TITLE
User CSS context menu settings fix

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -36,7 +36,7 @@ override_dh_install:
 	mkdir -p "$(DESTDIR)/etc/shellinabox/options-available"
 	mkdir -p "$(DESTDIR)/etc/shellinabox/options-enabled"
 	for i in \
-		"00+Black on White" \
+		"00+Black On White" \
 		"00_White On Black" \
 		"01_Monochrome" \
 		"01+Color Terminal"; do \

--- a/shellinabox/vt100.jspp
+++ b/shellinabox/vt100.jspp
@@ -329,7 +329,7 @@ VT100.prototype.getUserSettings = function() {
       this.disableAlt       = settings.charAt(5) != '0';
       if (typeof userCSSList != 'undefined') {
         for (var i = 0; i < userCSSList.length; ++i) {
-          userCSSList[i][2] = settings.charAt(i + 5) != '0';
+          userCSSList[i][2] = settings.charAt(i + 6) != '0';
         }
       }
     }
@@ -370,18 +370,10 @@ VT100.prototype.initializeUserCSSStyles = function() {
 
         // Add user style sheet to document
         var style                        = document.createElement('link');
-        var id                           = document.createAttribute('id');
-        id.nodeValue                     = 'usercss-' + i;
-        style.setAttributeNode(id);
-        var rel                          = document.createAttribute('rel');
-        rel.nodeValue                    = 'stylesheet';
-        style.setAttributeNode(rel);
-        var href                         = document.createAttribute('href');
-        href.nodeValue                   = 'usercss-' + i + '.css';
-        style.setAttributeNode(href);
-        var type                         = document.createAttribute('type');
-        type.nodeValue                   = 'text/css';
-        style.setAttributeNode(type);
+        style.setAttribute('id',           'usercss-' + i);
+        style.setAttribute('href',         'usercss-' + i + '.css');
+        style.setAttribute('rel',          'stylesheet');
+        style.setAttribute('type',         'text/css');
         document.getElementsByTagName('head')[0].appendChild(style);
         style.disabled                   = !enabled;
       }

--- a/shellinabox/vt100.jspp
+++ b/shellinabox/vt100.jspp
@@ -375,7 +375,23 @@ VT100.prototype.initializeUserCSSStyles = function() {
         style.setAttribute('rel',          'stylesheet');
         style.setAttribute('type',         'text/css');
         document.getElementsByTagName('head')[0].appendChild(style);
-        style.disabled                   = !enabled;
+
+        // If stylesheet needs to be disabled we need to do that from onload
+        // event, otherwise 'disabled' attribute will be ignored.
+        if (!enabled) {
+          if ('onload' in style) {
+            style.onload                     = function(style) {
+              return function () {
+                style.disabled               = true;
+              }
+            }(style);
+          } else {
+            // If onload event is not supported we will try to do it the old
+            // way. This also works sometimes, mosty in cases when browser
+            // already has cached version of stylesheet.
+            style.disabled                   = true;
+          }
+        }
       }
 
       // Add entry to menu


### PR DESCRIPTION
* Fixed initialization of user CSS settings from cookie. Now we the correct
  values are being read. This could be possible fix for issue #138.
* Changed generation of CSS link elements to get rid of JS deprecated
  warnings.