### PR TITLE
clean up debian/rules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,1 +1,1 @@
-Please see CHANGELOG.md
+CHANGELOG.md

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,17 +12,12 @@ noinst_HEADERS       = libhttp/http.h
 dist_doc_DATA        = AUTHORS                                                \
                        COPYING                                                \
                        GPL-2                                                  \
-                       CHANGELOG.md                                           \
-                       INSTALL                                                \
-                       NEWS                                                   \
-                       README                                                 \
-                       TODO                                                   \
-                       shellinabox/white-on-black.css                         \
-                       shellinabox/black-on-white.css                         \
-                       shellinabox/monochrome.css                             \
-                       shellinabox/color.css
+                       NEWS
 EXTRA_DIST           = INSTALL.Debian                                         \
                        README.Fedora                                          \
+                       INSTALL                                                \
+                       README                                                 \
+                       TODO                                                   \
                        demo/beep.wav                                          \
                        demo/favicon.ico                                       \
                        demo/demo.html                                         \
@@ -44,6 +39,10 @@ EXTRA_DIST           = INSTALL.Debian                                         \
                        shellinabox/shell_in_a_box.js                          \
                        shellinabox/vt100.js                                   \
                        shellinabox/cgi-mode-example.sh                        \
+                       shellinabox/white-on-black.css                         \
+                       shellinabox/black-on-white.css                         \
+                       shellinabox/monochrome.css                             \
+                       shellinabox/color.css                                  \
                        debian/README                                          \
                        debian/README.available                                \
                        debian/README.enabled                                  \

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ shellinabox (2.15-1) UNRELEASED; urgency=medium
   * Bump debhelper compat to 9
   * move lintian exception in d/shellinabox.lintian
   * change urls to new GitHub repos
+  * Closing release coordination metabug (Closes: #785181)
 
  -- Alexandre Detiste <alexandre.detiste@gmail.com>  Tue, 12 May 2015 14:06:55 +0200
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,10 +1,5 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
-# Sample debian/rules that uses debhelper.
-# This file was originally written by Joey Hess and Craig Small.
-# As a special exception, when this file is copied by dh-make into a
-# dh-make output file, you may use that output file without restriction.
-# This special exception was added by Craig Small in version 0.37 of dh-make.
 
 # Uncomment this to turn on verbose mode.
 #export DH_VERBOSE=1
@@ -20,38 +15,19 @@
 override_dh_auto_configure:
 	dh_auto_configure -- --disable-runtime-loading
 
-# elf-2012.03.24: This work should be done in the Makefile install
-#		  target instead of debian/rules.
-DESTDIR=$(CURDIR)/debian/tmp
+AVAILABLE=debian/shellinabox/etc/shellinabox/options-available
+ENABLED=debian/shellinabox/etc/shellinabox/options-enabled
 override_dh_install:
-	dh_testdir
-	dh_testroot
-	dh_prep
-	dh_installdirs
-# We need to install some files for the benefit of Debian that aren't
-# going into the program instal target.  So, we install into
-# debian/tmp the things that need to be included in the package.
-	$(MAKE) install DESTDIR=$(DESTDIR)
-# Set up system-wide user CSS style options
-	mkdir -p "$(DESTDIR)/etc/shellinabox/options-available"
-	mkdir -p "$(DESTDIR)/etc/shellinabox/options-enabled"
-	for i in \
-		"00+Black On White" \
-		"00_White On Black" \
-		"01_Monochrome" \
-		"01+Color Terminal"; do \
-	  cp "$(DESTDIR)/usr/share/doc/shellinabox/$$(echo "$$i"|	\
-		sed -e 's/[0-9]*[_+]\([^ ]*\).*/\1/'| 			\
-		tr A-Z a-z)"*.css                     			\
-	     "$(DESTDIR)/etc/shellinabox/options-available/$$i.css";	\
-	done
-	cd "$(DESTDIR)/etc/shellinabox/options-enabled" \
-	  && ln -s ../options-available/*.css .
-	cp "$(CURDIR)/debian/README.available"                                \
-	   "$(DESTDIR)/etc/shellinabox/options-available/README"
-	cp "$(CURDIR)/debian/README.enabled"                                  \
-	   "$(DESTDIR)/etc/shellinabox/options-enabled/README"
-# Shellinabox home directory
-#	mkdir -p "$(DESTDIR)/var/lib/shellinabox"
-# Now perform the normal debhelper install.
 	dh_install
+	install -D -m644 shellinabox/black-on-white.css "$(AVAILABLE)/00+Black on White.css"
+	install -D -m644 shellinabox/white-on-black.css "$(AVAILABLE)/00_White On Black.css"
+	install -D -m644 shellinabox/color.css          "$(AVAILABLE)/01+Color Terminal.css"
+	install -D -m644 shellinabox/monochrome.css     "$(AVAILABLE)/01_Monochrome.css"
+	install -D -m644 debian/README.available        "$(AVAILABLE)/README"
+	install -D -m644 debian/README.enabled          "$(ENABLED)/README"
+	cd "$(ENABLED)" && ln -s ../options-available/*.css .
+
+	# info duplicated in debian/copyright
+	# and /usr/share/common-licenses/GPL-2
+	rm debian/shellinabox/usr/share/doc/shellinabox/COPYING
+	rm debian/shellinabox/usr/share/doc/shellinabox/GPL-2

--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ ENABLED=debian/shellinabox/etc/shellinabox/options-enabled
 override_dh_install:
 	dh_install
 	install -D -m644 shellinabox/black-on-white.css "$(AVAILABLE)/00+Black on White.css"
-	install -D -m644 shellinabox/white-on-black.css "$(AVAILABLE)/00_White On Black.css"
+	install -D -m644 shellinabox/white-on-black.css "$(AVAILABLE)/00_White on Black.css"
 	install -D -m644 shellinabox/color.css          "$(AVAILABLE)/01+Color Terminal.css"
 	install -D -m644 shellinabox/monochrome.css     "$(AVAILABLE)/01_Monochrome.css"
 	install -D -m644 debian/README.available        "$(AVAILABLE)/README"

--- a/debian/shellinabox.install
+++ b/debian/shellinabox.install
@@ -1,4 +1,0 @@
-etc/shellinabox/options-available
-etc/shellinabox/options-enabled
-usr/bin
-usr/share/man/man1


### PR DESCRIPTION
so much more simple to read, yet it yelds an identical .deb

For people building the package without debian tools,
the 4 *.css won't be installed in /usr/share/doc/shellinabox;
anymore, but those aren't _documentation_,
merely sample configuration files.

The stubby Changelog "Please see CHANGELOG.md" is replaced
by a symlink; that explains the size increase of 6kb;
but Debian package should by policy ship the upstream
CHANGELOG if avaible.

```
debdiff GOOD_shellinabox_2.15-1_armhf.deb shellinabox_2.15-1_armhf.deb

File lists identical (after any substitutions)

Control files: lines which differ (wdiff format)
------------------------------------------------

Installed-Size: [-510-] {+516+}
```