### PR TITLE
Real IP recognition over proxy (partial fix #54)

### DIFF
--- a/libhttp/http.h
+++ b/libhttp/http.h
@@ -127,6 +127,7 @@ Server *httpGetServer(const HttpConnection *http);
 ServerConnection *httpGetServerConnection(const HttpConnection *);
 int httpGetFd(const HttpConnection *http);
 const char *httpGetPeerName(const HttpConnection *http);
+const char *httpGetRealIP(const HttpConnection *http);
 const char *httpGetMethod(const HttpConnection *http);
 const char *httpGetVersion(const HttpConnection *http);
 const HashMap *httpGetHeaders(const HttpConnection *http);

--- a/libhttp/httpconnection.c
+++ b/libhttp/httpconnection.c
@@ -1889,6 +1889,10 @@ const char *httpGetPeerName(const struct HttpConnection *http) {
   return http->peerName;
 }
 
+const char *httpGetRealIP(const struct HttpConnection *http) {
+  return getFromHashMap(&http->header, "x-real-ip");
+}
+
 const char *httpGetMethod(const struct HttpConnection *http) {
   return http->method;
 }

--- a/libhttp/httpconnection.h
+++ b/libhttp/httpconnection.h
@@ -148,6 +148,7 @@ struct Server *httpGetServer(const struct HttpConnection *http);
 struct ServerConnection *httpGetServerConnection(const struct HttpConnection*);
 int         httpGetFd(const HttpConnection *http);
 const char *httpGetPeerName(const struct HttpConnection *http);
+const char *httpGetRealIP(const struct HttpConnection *http);
 const char *httpGetMethod(const struct HttpConnection *http);
 const char *httpGetProtocol(const struct HttpConnection *http);
 const char *httpGetHost(const struct HttpConnection *http);

--- a/shellinabox/launcher.h
+++ b/shellinabox/launcher.h
@@ -56,6 +56,7 @@ struct LaunchRequest {
   int   width, height;
   pid_t terminate;
   char  peerName[128];
+  char  realIP[128];
   int   urlLength;
   char  url[0];
 };

--- a/shellinabox/shellinaboxd.c
+++ b/shellinabox/shellinaboxd.c
@@ -800,6 +800,7 @@ static void usage(void) {
           "  ${home}    - home directory\n"
           "  ${lines}   - number of rows\n"
           "  ${peer}    - name of remote peer\n"
+          "  ${realip}  - value of HTTP header field 'X-Real-IP'\n"
           "  ${uid}     - user id\n"
           "  ${url}     - the URL that serves the terminal session\n"
           "  ${user}    - user name\n"

--- a/shellinabox/shellinaboxd.man.in
+++ b/shellinabox/shellinaboxd.man.in
@@ -449,6 +449,9 @@ number of rows.
 .B ${peer}
 name of remote peer.
 .TP
+.B ${realip}
+value of HTTP header field 'X-Real-IP'.
+.TP
 .B ${uid}
 numeric user id.
 .TP
@@ -458,11 +461,14 @@ the URL that serves the terminal session.
 .B ${user}
 user name.
 .P
-Other than the default environment variables of
+Other than the environment variables of
 .BR $TERM ,
-.B $COLUMNS
+.B $COLUMNS,
+.B $LINES,
+.B $SHELLINABOX_PEERNAME,
+.B $SHELLINABOX_REALIP
 and
-.BR $LINES ,
+.BR $SHELLINABOX_URL,
 services can have environment variables passed to them, by preceding
 the <cmdline> with space separated variable assignments of the form
 .IR KEY = VALUE .


### PR DESCRIPTION
* Recogniton of HTTP header field 'X-Real-IP' was added. Value
  is used in LOGIN service with peer name as remote host identifier.
  This was we are able to see real IP in login related log files
  such as /var/log/auth.log, etc...

  Example for failed logins over nginx as can be seen in `/var/log/auth.log` file:
  ```
  May 17 20:17:20 luka-ubuntu login[9888]: FAILED LOGIN (1) on '/dev/pts/20' from '127.0.0.1, 192.168.1.100' FOR 'UNKNOWN', User not known to the underlying authentication module
  May 17 20:17:25 luka-ubuntu login[9888]: FAILED LOGIN (2) on '/dev/pts/20' from '127.0.0.1, 192.168.1.100' FOR 'luka', Authentication failure
  ```


* Real IP, peer name and URL are also passed to launched  service
  as environment variables (SHELLINABOX_PEERNAME, SHELLINABOX_REALIP
  and SHELLINABOX_URL). This can be used by custom user service shell
  scripts or programs.

  ```
  SHELLINABOX_REALIP=192.168.1.100
  SHELLINABOX_URL=http://192.168.1.150:81/
  SHELLINABOX_PEERNAME=127.0.0.1
  ```

* Real IP can also be passed to custom user service as command line
  parameter ${realip}.

  See this example:
  ```
  ./shellinaboxd --service  '/:luka:luka:/:/home/luka/test.sh --peer ${peer} --realip ${realip}'
  ```