### PR TITLE
debian: preserve user options on upgrade

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ shellinabox (2.15-1) UNRELEASED; urgency=medium
   * move lintian exception in d/shellinabox.lintian
   * change urls to new GitHub repos
   * Closing release coordination metabug (Closes: #785181)
+  * keep user preferences on upgrade (Closes: #786441)
 
  -- Alexandre Detiste <alexandre.detiste@gmail.com>  Tue, 12 May 2015 14:06:55 +0200
 

--- a/debian/rules
+++ b/debian/rules
@@ -20,12 +20,11 @@ ENABLED=debian/shellinabox/etc/shellinabox/options-enabled
 override_dh_install:
 	dh_install
 	install -D -m644 shellinabox/black-on-white.css "$(AVAILABLE)/00+Black on White.css"
-	install -D -m644 shellinabox/white-on-black.css "$(AVAILABLE)/00_White on Black.css"
+	install -D -m644 shellinabox/white-on-black.css "$(AVAILABLE)/00_White On Black.css"
 	install -D -m644 shellinabox/color.css          "$(AVAILABLE)/01+Color Terminal.css"
 	install -D -m644 shellinabox/monochrome.css     "$(AVAILABLE)/01_Monochrome.css"
 	install -D -m644 debian/README.available        "$(AVAILABLE)/README"
 	install -D -m644 debian/README.enabled          "$(ENABLED)/README"
-	cd "$(ENABLED)" && ln -s ../options-available/*.css .
 
 	# info duplicated in debian/copyright
 	# and /usr/share/common-licenses/GPL-2

--- a/debian/shellinabox.postinst
+++ b/debian/shellinabox.postinst
@@ -29,6 +29,16 @@ case "$1" in
 	# can write the certificate even when the daemon has given-up
 	# root privileges.
 #      chown shellinabox:shellinabox /var/lib/shellinabox
+
+      # new install, enable all options
+      if [ -z "$2" ]; then
+         (cd /etc/shellinabox/options-enabled; ln -s ../options-available/*.css .)
+      # upgrade from <= v2.14, re-enable saved options
+      elif [ -d /etc/shellinabox/options-enabled-save ]; then
+         mv /etc/shellinabox/options-enabled-save/*.css /etc/shellinabox/options-enabled
+         rm -r /etc/shellinabox/options-enabled-save
+      fi
+      # future upgrades: no-op
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/shellinabox.postrm
+++ b/debian/shellinabox.postrm
@@ -33,6 +33,7 @@ case "$1" in
         deluser  --quiet --system shellinabox > /dev/null || true
         delgroup --quiet --system shellinabox > /dev/null || true
 	[ ! -d "$d" ] || rmdir "$d" || true    # deluser can't do this for /var
+	rm -rf "/etc/shellinabox/options-enabled"
 	exit 0
     ;;
 esac

--- a/debian/shellinabox.preinst
+++ b/debian/shellinabox.preinst
@@ -10,10 +10,13 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
+#DEBHELPER#
+
 case "$1" in
     upgrade)
 	# save old configuration
 	test -d /etc/shellinabox/options-enabled || exit 0
+	ls /etc/shellinabox/options-enabled/*.css > /dev/null 2>&1 || exit 0
 	if dpkg --compare-versions "$2" le "2.14-1"; then
 		mkdir -p /etc/shellinabox/options-enabled-save
 		cp -a /etc/shellinabox/options-enabled/*.css /etc/shellinabox/options-enabled-save
@@ -28,5 +31,3 @@ case "$1" in
         exit 1
     ;;
 esac
-
-#DEBHELPER#

--- a/debian/shellinabox.preinst
+++ b/debian/shellinabox.preinst
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+set -e
+
+# summary of how this script can be called:
+#        * <new-preinst> `install'
+#        * <new-preinst> `install' <old-version>
+#        * <new-preinst> `upgrade' <old-version>
+#        * <old-preinst> `abort-upgrade' <new-version>
+# for details, see http://www.debian.org/doc/debian-policy/ or
+# the debian-policy package
+
+case "$1" in
+    upgrade)
+	# save old configuration
+	test -d /etc/shellinabox/options-enabled || exit 0
+	if dpkg --compare-versions "$2" le "2.14-1"; then
+		mkdir -p /etc/shellinabox/options-enabled-save
+		cp -a /etc/shellinabox/options-enabled/*.css /etc/shellinabox/options-enabled-save
+	fi
+    ;;
+
+    install|abort-upgrade)
+    ;;
+
+    *)
+        echo "preinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+#DEBHELPER#


### PR DESCRIPTION
this is so much pain to get it right :wink: , the preinst has to save the active options somewhere so that the postinst finds them when it's run.

@KLuka I'm sorry I have to revert your cosmetic change of `00_White On Black.css` -> `00_White on Black.css` again, but without that, and because of the way Debian process the conffiles, the user would end up with _both_ installed or dangling symlinks in `/options-enabled/`

now I would test the package with `cowbuilder` & `piuparts` before considering publishing a release
@beewoolie 

![people back to the future grayscale white hair doc brown christopher lloyd blackboard 2048x1303 w_www wallpaperno com_68](https://cloud.githubusercontent.com/assets/7994192/7836591/8f8047dc-0481-11e5-9c0d-3116cf39a963.jpg)