### PR TITLE
Message passing to embedded shellinabox

### DIFF
--- a/misc/embedded.html
+++ b/misc/embedded.html
@@ -1,24 +1,38 @@
 <!DOCTYPE HTML>
 <!--
 
-	Example page with embedded Shell In A Box.
+	##
+	# Example page with embedded Shell In A Box.
+	#
 
 	On this page we can see how Shell In A Box can be embedded in another page and
-	how can we comunicate with it. For communication with Shell In A Box we need to set
-	'-m' (messages-origin) command line option with appropriate message origin.
+	how can we comunicate with it.
 
-	Example:
+	##
+	# Server Side
+	#
 
-		shellinaboxd -p 4200 -m 'https://192.168.1.150:4200'
+	For communication with Shell In A Box we need to set '-m' (messages-origin)
+	command line option with appropriate messages origin. Origin should be set to
+	URL of parent (this) window. If origin is set to '*' Shell In A Box won't checki
+	origin on received messages. This is usually unsafe option.
+
+	Command line example:
+
+		shellinaboxd -p 4200 -m 'https://192.168.1.150'
+
+	##
+	# Client Side
+	#
 
 	Shell In A Box accepts messages formated as JSON strings with 'type' and 'data'
-	fields. Messages with same formate can be passed back to parent (this) window.
+	fields. Messages with same format can be passed back to parent (this) window.
 
-	Example:
+	Message example:
 
 		var message = JSON.stringify({
-			type = "type",
-			data = "data"
+			type : "message type",
+			data : "additional data"
 		});
 
 	Messages are passed with function postMessage() and are received in "message"
@@ -33,11 +47,22 @@
 
 	Following types of messages can be received from shellinabox:
 
-		output	- data field contains terminal output (of last request)
+		output	- data field contains terminal output
 		session - data field contains session status (active or closed)
+
+	Example for passing command to Shell In A Box frame:
+
+		iframe.contentWindow.postMessage(JSON.stringify({
+			type : "input",
+			data : "ls -l\n"
+		}), "https://192.168.1.150:4200");
 
 	Please note that message passing and JSON operations are only supported on moderen
 	browsers.
+
+	##
+	# Info
+	#
 
 	For working examples please see HTML and JS code bellow...
 
@@ -79,9 +104,9 @@
 
 	<p id="session">Session status: ???</p>
 
-	<!-- Embedded shellinabox, in out case src attribute will be added with help
-		of JS
-		-->
+	<!--
+		Embedded shellinabox. In our case src attribute will be added with help
+		of JS. -->
 	<iframe id="shell" src=""></iframe>
 
 	<!-- Ouput -->
@@ -98,8 +123,8 @@
 		var output  = document.getElementById("output");
 		var session = document.getElementById("session");
 
-		// Add url to our iframe. We do this, only that variable 'url' is used
-		// throughout the whole code.
+		// Add url to our iframe. We do this, only that variable 'url' can be used
+		// throughout the whole code where needed.
 		iframe.src = url;
 
 		document.getElementById("execute").addEventListener("click", function() {
@@ -127,6 +152,8 @@
 				data : 'disable'
 			});
 			iframe.contentWindow.postMessage(message, url);
+			// Clear output window
+			output.innerHTML = '';
 		});
 
 		document.getElementById("session-reload").addEventListener("click", function() {

--- a/misc/embedded.html
+++ b/misc/embedded.html
@@ -1,0 +1,165 @@
+<!DOCTYPE HTML>
+<!--
+
+	Example page with embedded Shell In A Box.
+
+	On this page we can see how Shell In A Box can be embedded in another page and
+	how can we comunicate with it. For communication with Shell In A Box we need to set
+	'-m' (messages-origin) command line option with appropriate message origin.
+
+	Example:
+
+		shellinaboxd -p 4200 -m 'https://192.168.1.150:4200'
+
+	Shell In A Box accepts messages formated as JSON strings with 'type' and 'data'
+	fields. Messages with same formate can be passed back to parent (this) window.
+
+	Example:
+
+		var message = JSON.stringify({
+			type = "type",
+			data = "data"
+		});
+
+	Messages are passed with function postMessage() and are received in "message"
+	events.
+
+	Following types of message can be sent to shellinabox:
+
+		input	- writes content of data field to terminal
+		output	- enables passing of output to parent window (data field must be set
+				  to enable, disable or toggle)
+		session	- request sessions status
+
+	Following types of messages can be received from shellinabox:
+
+		output	- data field contains terminal output (of last request)
+		session - data field contains session status (active or closed)
+
+	Please note that message passing and JSON operations are only supported on moderen
+	browsers.
+
+	For working examples please see HTML and JS code bellow...
+
+	For more info and browser limitations on iframe message passing please check:
+	https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
+
+-->
+<html>
+<head>
+	<style>
+		p {
+			font-size:	1.1em;
+		}
+		#shell, #output {
+			width:		640px;
+			height:		300px;
+			margin: 	20px 10px;
+		}
+		#output {
+			overflow:	scroll;
+			border:		2px solid #999;
+		}
+	</style>
+</head>
+<body>
+
+	<h3>
+		Embedded Shell In A Box example page.
+	</h3>
+
+	<p>Controls:</p>
+	<div>
+		<input type="text"   id="input"></input>
+		<input type="button" id="execute" value="Execute"></input>
+		<input type="button" id="output-enable"  value="Output Enable"></input>
+		<input type="button" id="output-disable" value="Output Disable"></input>
+		<input type="button" id="session-reload" value="Session Status"></input>
+	</div>
+
+	<p id="session">Session status: ???</p>
+
+	<!-- Embedded shellinabox, in out case src attribute will be added with help
+		of JS
+		-->
+	<iframe id="shell" src=""></iframe>
+
+	<!-- Ouput -->
+	<p>Terminal output:</p>
+	<pre id="output"></pre>
+
+	<script>
+
+		// Shellinabox url
+		var url = "https://192.168.1.150:4200";
+
+		var input   = document.getElementById("input");
+		var iframe  = document.getElementById("shell");
+		var output  = document.getElementById("output");
+		var session = document.getElementById("session");
+
+		// Add url to our iframe. We do this, only that variable 'url' is used
+		// throughout the whole code.
+		iframe.src = url;
+
+		document.getElementById("execute").addEventListener("click", function() {
+			// Send input to shellinabox
+			var message = JSON.stringify({
+				type : 'input',
+				data : input.value + '\n'
+			});
+			iframe.contentWindow.postMessage(message, url);
+		});
+
+		document.getElementById("output-enable").addEventListener("click", function() {
+			// Enable output replay from shellinabox iframe
+			var message = JSON.stringify({
+				type : 'output',
+				data : 'enable'
+			});
+			iframe.contentWindow.postMessage(message, url);
+		});
+
+		document.getElementById("output-disable").addEventListener("click", function() {
+			// Disable output replay from shellinabox iframe
+			var message = JSON.stringify({
+				type : 'output',
+				data : 'disable'
+			});
+			iframe.contentWindow.postMessage(message, url);
+		});
+
+		document.getElementById("session-reload").addEventListener("click", function() {
+			// Request shellianbox session status
+			var message = JSON.stringify({
+				type : 'session'
+			});
+			iframe.contentWindow.postMessage(message, url);
+		});
+
+		// Receive response from shellinabox
+		window.addEventListener("message", function(message) {
+
+			// Allow messages only from shellinabox
+			if (message.origin !== url) {
+				return;
+			}
+
+			// Handle response according to response type
+			var decoded = JSON.parse(message.data);
+			switch (decoded.type) {
+			case "output" :
+				// Append new output
+				output.innerHTML = output.innerHTML + decoded.data;
+				break;
+			case "session" :
+				// Reload session status
+				session.innerHTML = 'Session status: ' + decoded.data;
+				break;
+			}
+		}, false);
+
+	</script>
+
+</body>
+</html>

--- a/shellinabox/shell_in_a_box.jspp
+++ b/shellinabox/shell_in_a_box.jspp
@@ -389,7 +389,7 @@ ShellInABox.prototype.messageInit = function() {
       }
     }(this), false);
   } else {
-    // For IE8 or lower
+    // For IE8
     if (window.attachEvent) {
       window.attachEvent('onmessage', function(shellInABox) {
         return function(message) {

--- a/shellinabox/shell_in_a_box.jspp
+++ b/shellinabox/shell_in_a_box.jspp
@@ -109,12 +109,15 @@ function ShellInABox(url, container) {
   this.pendingKeys  = '';
   this.keysInFlight = false;
   this.connected    = false;
+  this.replayOutput = false;
   this.superClass.constructor.call(this, container);
+
 
   // We have to initiate the first XMLHttpRequest from a timer. Otherwise,
   // Chrome never realizes that the page has loaded.
   setTimeout(function(shellInABox) {
                return function() {
+                 shellInABox.messageInit();
                  shellInABox.sendRequest();
                };
              }(this), 1);
@@ -192,6 +195,9 @@ ShellInABox.prototype.onReadyStateChange = function(request) {
       this.connected = true;
       var response   = eval('(' + request.responseText + ')');
       if (response.data) {
+        if (this.replayOutput) {
+          this.messageReplay('output', response.data);
+        }
         this.vt100(response.data);
       }
 
@@ -358,6 +364,87 @@ ShellInABox.prototype.extendContextMenu = function(entries, actions) {
     }
   }
 
+};
+
+ShellInABox.prototype.messageInit = function() {
+
+  // Test if server option for iframe message passing was set.
+  if (!serverMessagesOrigin) {
+    return;
+  }
+
+  // Test for browser support of this feature. JSON class functionality is
+  // also needed because some older IE browsers, support only string passing
+  // and we don't want to use unsafe eval() function in this case.
+  if (!window.postMessage || !window.JSON ||
+      !window.JSON.parse  || !window.JSON.stringify) {
+    return;
+  }
+
+  // Install event listener.
+  if (window.addEventListener) {
+    window.addEventListener('message', function(shellInABox) {
+      return function(message) {
+        shellInABox.messageReceive(message);
+      }
+    }(this), false);
+  } else {
+    // For IE8 or lower
+    if (window.attachEvent) {
+      window.attachEvent('onmessage', function(shellInABox) {
+        return function(message) {
+          shellInABox.messageReceive(message);
+        }
+      }(this));
+    }
+  }
+
+};
+
+ShellInABox.prototype.messageReceive = function (message) {
+
+  // Check for message origin if needed.
+  if (serverMessagesOrigin !== "*") {
+    if (serverMessagesOrigin !== message.origin) {
+      return;
+    }
+  }
+
+  // Remember replay information.
+  if (!this.replaySource || !this.replayOrigin) {
+    this.replaySource   = message.source;
+    this.replayOrigin   = message.origin;
+  }
+
+  // Handle received message.
+  var decoded           = JSON.parse(message.data);
+  switch (decoded.type) {
+  case 'input'  :
+    // Input received data to terminal.
+    this.keysPressed(decoded.data);
+    break;
+  case 'output' :
+    // Enable, disable or toggle passing terminal output to parent window.
+    if (decoded.data === 'enable') {
+      this.replayOutput = true;
+    } else if (decoded.data === 'disable') {
+      this.replayOutput = false;
+    } else if (decoded.data === 'toggle') {
+      this.replayOutput = !this.replayOutput;
+    }
+    break;
+  case 'session':
+    // Replay with session status.
+    this.messageReplay('session', this.session ? 'alive' : 'closed');
+    break;
+  }
+};
+
+ShellInABox.prototype.messageReplay = function(type, data) {
+  if (this.replaySource && this.replayOrigin) {
+    var encoded = JSON.stringify({ type : type, data : data });
+    this.replaySource.postMessage(encoded, this.replayOrigin);
+  }
 };
 
 ShellInABox.prototype.about = function() {


### PR DESCRIPTION
Added support for messages passing to or from embedded shellinabox frame. This has to be enabled with --messages-origin command line switch. Example file with additional info and instructions on how to use this feature was also added.