### PR TITLE
fix typo: HTTPS --> HTTP

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,7 @@ shellinabox (2.19) unstable; urgency=high
   * Added support for middle-click paste, #350.
   * Improved iOS support, #354.
   * New logic to enable soft keyboard icon, #119, #321, #354.
-  * Disable HTTPS fallback using the URL /plain.  Consequently disables
+  * Disable HTTP fallback using the URL /plain.  Consequently disables
     automatic upgrades from HTTP to HTTPS, #355. (CVE-2015-8400).
 
  -- Marc Singer <elf@debian.org>  Sat, 05 Dec 2015 10:24:12 -0800


### PR DESCRIPTION
This fixes a typo in the Debian `changelog`. Thank you!