### PR TITLE
Issue #222: LOGIN service (can't reopen tty)

### DIFF
--- a/shellinabox/session.c
+++ b/shellinabox/session.c
@@ -116,9 +116,11 @@ void initSession(struct Session *session, const char *sessionKey,
   session->http           = NULL;
   session->done           = 0;
   session->pty            = -1;
+  session->ptyFirstRead   = 1;
   session->width          = 0;
   session->height         = 0;
   session->buffered       = NULL;
+  session->useLogin       = 0;
   session->len            = 0;
   session->pid            = 0;
   session->cleanup        = 0;

--- a/shellinabox/session.h
+++ b/shellinabox/session.h
@@ -58,9 +58,11 @@ struct Session {
   HttpConnection   *http;
   int              done;
   int              pty;
+  int              ptyFirstRead;
   int              width;
   int              height;
   char             *buffered;
+  int              useLogin;
   int              len;
   pid_t            pid;
   int              cleanup;


### PR DESCRIPTION
* Workaround for random "Session closed" issues related to /bin/login
  closing and reopening our pty during initialization. This happens only
  on some systems like Fedora for example. Now we allow that our pty is
  closed by ignoring POLLHUP on first read. Delay is also needed so that
  login process has some time to reopen pty.
* Note that the issue may occur anyway but with this workaround we reduce
  the chances.