### PR TITLE
2016-02-23 23:18 UTC+0100 Przemyslaw Czerpak (druzus/at/poczta.onet.pl)

### DIFF
--- a/shellinabox/vt100.jspp
+++ b/shellinabox/vt100.jspp
@@ -2841,7 +2841,7 @@ VT100.prototype.handleKey = function(event) {
       ch                              = part1                                 +
                                        ((event.shiftKey             ? 1 : 0)  +
                                         (event.altKey|event.metaKey ? 2 : 0)  +
-                                        (event.ctrlKey              ? 4 : 0)) +
+                                        (event.ctrlKey              ? 4 : 0) + 1) +
                                         part2;
     } else if (ch.length == 1 && (event.altKey || event.metaKey)
                && !this.disableAlt) {


### PR DESCRIPTION
  * shellinabox/vt100.jspp
    ! fixed key modifiers encoding.
      They should be calculated as bitfield for
         SHIFT = 1
         ALT   = 2
         CTRL  = 4
      and then incremented by 1.
      ref:
         http://www.xfree86.org/4.7.0/ctlseqs.html#PC-Style%20Function%20Keys
         http://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-PC-Style-Function-Keys