### PR TITLE
adjust scale on IE

### DIFF
--- a/shellinabox/vt100.jspp
+++ b/shellinabox/vt100.jspp
@@ -1604,7 +1604,10 @@ VT100.prototype.updateWidth = function() {
       this.terminalWidth = Math.floor(this.console[this.currentScreen].offsetWidth/this.cursorWidth*this.scale);
     }
   } else {
-    this.terminalWidth = Math.floor(this.console[this.currentScreen].offsetWidth/this.cursorWidth*this.scale);
+    if ("ActiveXObject" in window)
+      this.terminalWidth = Math.floor(this.console[this.currentScreen].offsetWidth/this.cursorWidth*this.scale*0.95);
+    else
+      this.terminalWidth = Math.floor(this.console[this.currentScreen].offsetWidth/this.cursorWidth*this.scale);
   }
 
   return this.terminalWidth;


### PR DESCRIPTION
On IE 11 the computed width (nr of columns) is too large. 
I loose on average about 3 characters on the right side. 

This is a quick hack to fix this.