### PR TITLE
Fix a debug check on FreeBSD and probably Linux

### DIFF
--- a/libhttp/httpconnection.c
+++ b/libhttp/httpconnection.c
@@ -430,7 +430,7 @@ void destroyHttpConnection(struct HttpConnection *http) {
             http->peerName ? http->peerName : "???", http->peerPort);
     }
     httpShutdown(http, http->closed ? SHUT_WR : SHUT_RDWR);
-    dcheck(!close(http->fd));
+    dcheck(!close(http->fd) || errno != EBADF);
     free(http->peerName);
     free(http->url);
     free(http->method);


### PR DESCRIPTION
On FreeBSD 12.0 I get within a minute:

Check failed at libhttp/httpconnection.c:433 in destroyHttpConnection(): !close(http->fd)

See also:

https://github.com/shellinabox/shellinabox/issues/389

I assume that close() fails with ECONNRESET and that we should just check
for errno != EBADF, which should also be OK for Linux and other systems,
which might return EIO in some conditions.

Linux close(2) manual page:

	EBADF	fd isn't a valid open file descriptor.
	EINTR	The close() call was interrupted by a signal; see signal(7).
	EIO	An I/O error occurred.

FreeBSD close(2) manual page:

     [EBADF]            The fd argument is not an active descriptor.
     [EINTR]            An interrupt was received.
     [ENOSPC]           The underlying object did not fit, cached data was
                        lost.
     [ECONNRESET]       The underlying object was a stream socket that was
                        shut down by the peer before all pending data was
                        delivered.

     In case of any error except EBADF, the supplied file descriptor is
     deallocated and therefore is no longer valid.