### PR TITLE
#342 Adding selinux policy. TODO: Unconfined context misuse needed to fix

### DIFF
--- a/misc/selinux/shellinabox/README
+++ b/misc/selinux/shellinabox/README
@@ -1,0 +1,12 @@
+Installing SElinux policy
+================================
+
+Prior to build and use this selinux module, you've to install selinux devel package 
+On a Fedora distrib use :
+# yum install selinux-policy-devel
+
+Then execute with root shellinaboxd.sh script that will build and load the new policy module.
+# ./shellinaboxd.sh
+
+Restart shellinaboxd service to make sure context daemon use the correct execution context :
+# systemctl restart shellinaboxd.service

--- a/misc/selinux/shellinabox/shellinaboxd.fc
+++ b/misc/selinux/shellinabox/shellinaboxd.fc
@@ -1,0 +1,5 @@
+/usr/lib/systemd/system/shellinaboxd.service		--	gen_context(system_u:object_r:shellinaboxd_unit_file_t,s0)
+
+/usr/sbin/shellinaboxd		--	gen_context(system_u:object_r:shellinaboxd_exec_t,s0)
+
+/var/lib/shellinabox(/.*)?		gen_context(system_u:object_r:shellinaboxd_var_lib_t,s0)

--- a/misc/selinux/shellinabox/shellinaboxd.if
+++ b/misc/selinux/shellinabox/shellinaboxd.if
@@ -1,0 +1,184 @@
+
+## <summary>policy for shellinaboxd</summary>
+
+########################################
+## <summary>
+##	Execute shellinaboxd_exec_t in the shellinaboxd domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`shellinaboxd_domtrans',`
+	gen_require(`
+		type shellinaboxd_t, shellinaboxd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, shellinaboxd_exec_t, shellinaboxd_t)
+')
+
+######################################
+## <summary>
+##	Execute shellinaboxd in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`shellinaboxd_exec',`
+	gen_require(`
+		type shellinaboxd_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, shellinaboxd_exec_t)
+')
+
+########################################
+## <summary>
+##	Search shellinaboxd lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`shellinaboxd_search_lib',`
+	gen_require(`
+		type shellinaboxd_var_lib_t;
+	')
+
+	allow $1 shellinaboxd_var_lib_t:dir search_dir_perms;
+	files_search_var_lib($1)
+')
+
+########################################
+## <summary>
+##	Read shellinaboxd lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`shellinaboxd_read_lib_files',`
+	gen_require(`
+		type shellinaboxd_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	read_files_pattern($1, shellinaboxd_var_lib_t, shellinaboxd_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage shellinaboxd lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`shellinaboxd_manage_lib_files',`
+	gen_require(`
+		type shellinaboxd_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_files_pattern($1, shellinaboxd_var_lib_t, shellinaboxd_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage shellinaboxd lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`shellinaboxd_manage_lib_dirs',`
+	gen_require(`
+		type shellinaboxd_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_dirs_pattern($1, shellinaboxd_var_lib_t, shellinaboxd_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Execute shellinaboxd server in the shellinaboxd domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`shellinaboxd_systemctl',`
+	gen_require(`
+		type shellinaboxd_t;
+		type shellinaboxd_unit_file_t;
+	')
+
+	systemd_exec_systemctl($1)
+        systemd_read_fifo_file_passwd_run($1)
+	allow $1 shellinaboxd_unit_file_t:file read_file_perms;
+	allow $1 shellinaboxd_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, shellinaboxd_t)
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an shellinaboxd environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <param name="role">
+##	<summary>
+##	Role allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`shellinaboxd_admin',`
+	gen_require(`
+		type shellinaboxd_t;
+		type shellinaboxd_var_lib_t;
+	type shellinaboxd_unit_file_t;
+	')
+
+	allow $1 shellinaboxd_t:process { signal_perms };
+	ps_process_pattern($1, shellinaboxd_t)
+
+    tunable_policy(`deny_ptrace',`',`
+        allow $1 shellinaboxd_t:process ptrace;
+    ')
+
+	files_search_var_lib($1)
+	admin_pattern($1, shellinaboxd_var_lib_t)
+
+	shellinaboxd_systemctl($1)
+	admin_pattern($1, shellinaboxd_unit_file_t)
+	allow $1 shellinaboxd_unit_file_t:service all_service_perms;
+	optional_policy(`
+		systemd_passwd_agent_exec($1)
+		systemd_read_fifo_file_passwd_run($1)
+	')
+')

--- a/misc/selinux/shellinabox/shellinaboxd.sh
+++ b/misc/selinux/shellinabox/shellinaboxd.sh
@@ -1,0 +1,52 @@
+#!/bin/sh -e
+
+DIRNAME=`dirname $0`
+cd $DIRNAME
+USAGE="$0 [ --update ]"
+if [ `id -u` != 0 ]; then
+echo 'You must be root to run this script'
+exit 1
+fi
+
+if [ $# -eq 1 ]; then
+	if [ "$1" = "--update" ] ; then
+		time=`ls -l --time-style="+%x %X" shellinaboxd.te | awk '{ printf "%s %s", $6, $7 }'`
+		rules=`ausearch --start $time -m avc --raw -se shellinaboxd`
+		if [ x"$rules" != "x" ] ; then
+			echo "Found avc's to update policy with"
+			echo -e "$rules" | audit2allow -R
+			echo "Do you want these changes added to policy [y/n]?"
+			read ANS
+			if [ "$ANS" = "y" -o "$ANS" = "Y" ] ; then
+				echo "Updating policy"
+				echo -e "$rules" | audit2allow -R >> shellinaboxd.te
+				# Fall though and rebuild policy
+			else
+				exit 0
+			fi
+		else
+			echo "No new avcs found"
+			exit 0
+		fi
+	else
+		echo -e $USAGE
+		exit 1
+	fi
+elif [ $# -ge 2 ] ; then
+	echo -e $USAGE
+	exit 1
+fi
+
+echo "Building and Loading Policy"
+set -x
+make -f /usr/share/selinux/devel/Makefile shellinaboxd.pp || exit
+/usr/sbin/semodule -i shellinaboxd.pp
+
+# Generate a man page off the installed module
+sepolicy manpage -p . -d shellinaboxd_t
+# Fixing the file context on /usr/sbin/shellinaboxd
+/sbin/restorecon -F -R -v /usr/sbin/shellinaboxd
+# Fixing the file context on /usr/lib/systemd/system/shellinaboxd.service
+/sbin/restorecon -F -R -v /usr/lib/systemd/system/shellinaboxd.service
+# Fixing the file context on /var/lib/shellinabox
+/sbin/restorecon -F -R -v /var/lib/shellinabox

--- a/misc/selinux/shellinabox/shellinaboxd.te
+++ b/misc/selinux/shellinabox/shellinaboxd.te
@@ -1,0 +1,102 @@
+policy_module(shellinaboxd, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type shellinaboxd_t;
+type shellinaboxd_exec_t;
+init_daemon_domain(shellinaboxd_t, shellinaboxd_exec_t)
+
+permissive shellinaboxd_t;
+
+type shellinaboxd_var_lib_t;
+files_type(shellinaboxd_var_lib_t)
+
+type shellinaboxd_unit_file_t;
+systemd_unit_file(shellinaboxd_unit_file_t)
+
+########################################
+#
+# shellinaboxd local policy
+#
+
+#============= shellinaboxd_t ==============
+require {
+    type systemd_logind_t;
+	type chkpwd_exec_t;
+	type shellinaboxd_t;
+	type security_t;
+	type unconfined_t;
+	type devpts_t;
+    type init_t;
+    type proc_t;
+	class capability { sys_tty_config sys_resource net_admin audit_write dac_override fsetid };
+	class tcp_socket { listen accept };
+	class process { setsched setexec transition setkeycreate };
+	class file { open read execute_no_trans execute };
+	class netlink_audit_socket { nlmsg_relay create };
+	class chr_file { open setattr relabelfrom relabelto };
+	class security { compute_relabel compute_user };
+}
+
+allow shellinaboxd_t chkpwd_exec_t:file { open read execute_no_trans execute };
+allow shellinaboxd_t devpts_t:chr_file { open setattr relabelto relabelfrom };
+allow shellinaboxd_t security_t:security { compute_relabel compute_user };
+allow shellinaboxd_t self:capability { sys_tty_config sys_resource net_admin audit_write dac_override fsetid };
+allow shellinaboxd_t self:netlink_audit_socket { nlmsg_relay create };
+allow shellinaboxd_t self:process { setsched setexec setkeycreate };
+allow shellinaboxd_t init_t:file { getattr open read };
+allow shellinaboxd_t proc_t:file { getattr open read };
+
+allow shellinaboxd_t systemd_logind_t:dbus send_msg;
+allow shellinaboxd_t self:tcp_socket { listen accept };
+
+allow shellinaboxd_t unconfined_t:process transition;
+
+allow shellinaboxd_t self:capability { chown setgid setuid };
+allow shellinaboxd_t self:process { fork setrlimit signal_perms };
+allow shellinaboxd_t self:fifo_file rw_fifo_file_perms;
+allow shellinaboxd_t self:unix_stream_socket create_stream_socket_perms;
+
+allow shellinaboxd_t chkpwd_exec_t:file { read execute_no_trans execute open };
+allow shellinaboxd_t default_context_t:file { read getattr open };
+
+allow systemd_logind_t shellinaboxd_t:dbus send_msg;
+
+auth_log_filetrans_login_records(shellinaboxd_t)
+auth_login_entry_type(shellinaboxd_t)
+auth_rw_faillog(shellinaboxd_t)
+auth_rw_lastlog(shellinaboxd_t)
+auth_tunable_read_shadow(shellinaboxd_t)
+auth_write_login_records(shellinaboxd_t)
+corecmd_shell_entry_type(shellinaboxd_t)
+corenet_tcp_bind_oa_system_port(shellinaboxd_t)
+dbus_system_bus_client(shellinaboxd_t)
+init_rw_utmp(shellinaboxd_t)
+logging_manage_generic_logs(shellinaboxd_t)
+seutil_read_default_contexts(shellinaboxd_t)
+term_getattr_pty_fs(shellinaboxd_t)
+term_relabel_all_ptys(shellinaboxd_t)
+term_use_generic_ptys(shellinaboxd_t)
+term_use_ptmx(shellinaboxd_t)
+
+manage_dirs_pattern(shellinaboxd_t, shellinaboxd_var_lib_t, shellinaboxd_var_lib_t)
+manage_files_pattern(shellinaboxd_t, shellinaboxd_var_lib_t, shellinaboxd_var_lib_t)
+manage_lnk_files_pattern(shellinaboxd_t, shellinaboxd_var_lib_t, shellinaboxd_var_lib_t)
+files_var_lib_filetrans(shellinaboxd_t, shellinaboxd_var_lib_t, { dir file lnk_file })
+
+domain_use_interactive_fds(shellinaboxd_t)
+
+files_read_etc_files(shellinaboxd_t)
+
+auth_use_nsswitch(shellinaboxd_t)
+
+logging_send_syslog_msg(shellinaboxd_t)
+
+miscfiles_read_localization(shellinaboxd_t)
+
+sysnet_dns_name_resolve(shellinaboxd_t)
+
+


### PR DESCRIPTION
#342 : module for shellinaboxd daemon.

There is still a problem using unconfined context transition when launching /bin/login but it's functional.

You need to execute the shellinaboxd.sh script as root to install the policy in your system. It also generate a RPM files that can be deployed on others systems.
