### PR TITLE
vt100.jspp: Interpret aixterm high-intensity color escape codes.

### DIFF
--- a/shellinabox/vt100.jspp
+++ b/shellinabox/vt100.jspp
@@ -3937,13 +3937,21 @@ VT100.prototype.csim = function() {
       break;
     default:
       if (this.par[i] >= 30 && this.par[i] <= 37) {
+          // set foreground color, colors 0-7 (ansi)
           var fg        = this.par[i] - 30;
           this.attr     = ((this.attr & ~0x0F) | fg) & ~(ATTR_DEF_FG);
           this.attrFg   = false;
       } else if (this.par[i] >= 40 && this.par[i] <= 47) {
+          // set background color, colors 0-7 (ansi)
           var bg        = this.par[i] - 40;
           this.attr     = ((this.attr & ~0xF0) | (bg << 4)) & ~(ATTR_DEF_BG);
           this.attrBg   = false;
+      } else if (this.par[i] >= 90 && this.par[i] <= 97) {
+          // set foreground color, colors 8-15 (aixterm high-intensity)
+          this.attrFg = this.par[i] - 82;
+      } else if (this.par[i] >= 100 && this.par[i] <= 107) {
+          // set background color, colors 8-15 (aixterm high-intensity)
+          this.attrBg = this.par[i] - 92;
       }
       break;
     }


### PR DESCRIPTION
These escape sequences are widely used by 256-color terminfo entries to set colors 8-15.

Without this change, there's a significant gap in color coverage when viewing curses output generated for otherwise "close enough" 256-color TERM values.

### Example:
The _screen-256color_ terminfo is __not__ a perfect match for shellinabox.  However, it provides good enough results for basic use and has a high chance of being available on a modern system.

The following shell command uses the _screen-256color_ terminfo to output "hello world" with bright yellow text (color 11) on a bright red background (color 9).
```Shell
(TERM=screen-256color; tput setaf 11; tput setab 9; printf "hello world"; tput op; printf "\n";)
```
Without this patch, the coloring is completely ignored.  With the patch, the coloring is applied successfully.
