### PR TITLE
add Let's Encrypt helper

### DIFF
--- a/contrib/shellinabox.conf
+++ b/contrib/shellinabox.conf
@@ -1,0 +1,4 @@
+# this goes in /lib/systemd/system/certbot.service.d/
+
+[Service]
+ExecStartPost=/usr/sbin/shellinabox_import_from_certbot

--- a/contrib/shellinabox_import_from_certbot
+++ b/contrib/shellinabox_import_from_certbot
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+
+# this goes in /usr/sbin/shellinabox_import_from_certbot
+
+# Copyright (C) 2017 Alexandre Detiste <alexandre@detiste.be>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#
+# You can find the GPL license text on a Debian system under
+# /usr/share/common-licenses/GPL-2.
+
+import os
+import subprocess
+
+if 'DEBUG' in os.environ:
+    debug = print
+else:
+    debug = lambda *args, **kwargs: None
+
+SOURCE='/etc/letsencrypt/live/'
+DEST='/var/lib/shellinabox/'
+
+source={}
+debug('SOURCE')
+for domain in next(os.walk(SOURCE))[1]:
+     mtime=os.path.getmtime(os.path.join(SOURCE, domain, 'cert.pem'))
+     debug(domain, mtime)
+     source[domain]=mtime
+
+dest={}
+debug('TO')
+for filename in next(os.walk(DEST))[2]:
+    domain=filename[12:-4]
+    if not domain:
+        continue
+    mtime=os.path.getmtime(os.path.join(DEST, filename))
+    debug(domain, mtime)
+    dest[domain]=mtime
+
+debug('RIGHT INNER JOIN')
+updated=False
+for domain, mtime in dest.items():
+    if domain not in source:
+        continue
+    if source[domain] < mtime:
+        continue
+    updated=True
+    print('Updating domain %s...' % domain)
+    with open(os.path.join(DEST,'certificate-%s.pem' % domain), 'w') as out:
+        out.write(open(os.path.join(SOURCE, domain, 'privkey.pem'), 'r').read())
+        out.write(open(os.path.join(SOURCE, domain, 'cert.pem'), 'r').read())
+
+if updated:
+    print('Restarting ShellInABox')
+    subprocess.check_call(['systemctl', 'try-restart', 'shellinabox'])


### PR DESCRIPTION
as I couldn't find anything online doing this, I came up with a solution myself.

purpose: this refresh ShellInABox certificate each time Let's Encrypt refresh is own's

I'm not sure about the `cat privkey.pem cert.pem > ssl.pem` stuff, I found it here:
https://nwgat.ninja/setting-up-letsencrypt-with-lighttpd/

as this needs an extra depedency (Python 3), this goes in contrib/
if needed I can rewrite it in shell.