### PR TITLE
Display Soft Keyboard by default on mobile devices

### DIFF
--- a/shellinabox/vt100.jspp
+++ b/shellinabox/vt100.jspp
@@ -300,7 +300,8 @@ VT100.prototype.getUserSettings = function() {
 
   // Enable soft keyboard icon on some clients by default.
   if (navigator.userAgent.match(/iPad|iPhone|iPod/i) != null ||
-      navigator.userAgent.match(/PlayStation Vita|Kindle/i) != null) {
+      navigator.userAgent.match(/PlayStation Vita|Kindle/i) != null ||
+      navigator.userAgent.match(/Mobile|Tablet/i) != null) {
     this.softKeyboard       = true;
   }
 


### PR DESCRIPTION
It's necessary on devices that have no keyboard and no mouse.
Looking for "Mobile" or "Tablet" word in the user-agent string, following Mozilla recommendations : https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox#Mobile_and_Tablet_indicators

It should work at least on devices running Firefox (tested on Firefox OS. Yes, I know this platform is dead ;-) )