### PR TITLE
support localhost as a hostname

### DIFF
--- a/shellinabox/launcher.c
+++ b/shellinabox/launcher.c
@@ -993,8 +993,8 @@ static pam_handle_t *internalLogin(struct Service *service, struct Utmp *utmp,
   if (service->authUser == 2 /* SSH */) {
     // If connecting to a remote host, include that hostname
     hostname                   = strrchr(service->cmdline, '@');
-    if (!hostname || !strcmp(++hostname, "localhost")) {
-      hostname                 = NULL;
+    if (hostname) {
+      hostname++
     }
   }
   struct utsname uts;


### PR DESCRIPTION
I've encounter a problem when it is necessary to pass localhost as a hostname argument:
`/usr/bin/shellinaboxd --disable-ssl --service /:SSH:localhost`
It becomes necessary when someone changes a hostname via hostname utility. In this case new hostname is not resolved, so i'm getting  an error when trying to connect to shellinaboxd