### PR TITLE
CVE-2018-16789: fix for broken multipart/form-data

### DIFF
--- a/libhttp/url.c
+++ b/libhttp/url.c
@@ -312,6 +312,9 @@ static void urlParsePostBody(struct URL *url,
               }
             }
           }
+        } else {
+           warn("[http] broken multipart/form-data!");
+           break;
         }
       }
       if (lastPart) {


### PR DESCRIPTION
Malformed multipart/form-data payload results in infinite loop and thus denial of service