### PR TITLE
Be stricter when matching URLs

### DIFF
--- a/shellinabox/vt100.jspp
+++ b/shellinabox/vt100.jspp
@@ -118,7 +118,8 @@ function VT100(container) {
     '(?::[1-9][0-9]*)?' +
 
     // Path.
-    '(?:/(?:(?![/ \u00A0]|[,.)}"\u0027!]+[ \u00A0]|[,.)}"\u0027!]+$).)*)*|' +
+    '(?:/(?:(?![/ \u00A0]|[,.)}"\u0027!]+[ \u00A0]|[,.)}"\u0027!]+$)' +
+    '[-a-zA-Z0-9@:%_\+.~#?&//=])*)*|' +
 
     (linkifyURLs <= 1 ? '' :
     // Also support URLs without a protocol (assume "http").
@@ -149,7 +150,8 @@ function VT100(container) {
     '(?::[1-9][0-9]{0,4})?' +
 
     // Path.
-    '(?:/(?:(?![/ \u00A0]|[,.)}"\u0027!]+[ \u00A0]|[,.)}"\u0027!]+$).)*)*|') +
+    '(?:/(?:(?![/ \u00A0]|[,.)}"\u0027!]+[ \u00A0]|[,.)}"\u0027!]+$)' +
+    '[-a-zA-Z0-9@:%_\+.~#?&//=])*)*|') +
 
     // In addition, support e-mail address. Optionally, recognize "mailto:"
     '(?:mailto:)' + (linkifyURLs <= 1 ? '' : '?') +


### PR DESCRIPTION
This change limits the characters matching the path part of a URL. One visible change is that the final '>' which usually encloses urls in emails - e.g., <https://github.com/shellinabox> - is not URLified anymore. Previously, this resulted in an URL ending with >, which lead to 404.