### PR TITLE
Fix "yellow bold" ansi color

### DIFF
--- a/shellinabox/color.css
+++ b/shellinabox/color.css
@@ -15,7 +15,7 @@
 #vt100 .ansi8     { color:            #7f7f7f; }
 #vt100 .ansi9     { color:            #ff0000; }
 #vt100 .ansi10    { color:            #00ff00; }
-#vt100 .ansi11    { color:            #e8e800; }
+#vt100 .ansi11    { color:            #ffff00; }
 #vt100 .ansi12    { color:            #5c5cff; }
 #vt100 .ansi13    { color:            #ff00ff; }
 #vt100 .ansi14    { color:            #00ffff; }

--- a/shellinabox/styles.css
+++ b/shellinabox/styles.css
@@ -261,7 +261,7 @@
 #vt100 .ansi8     { color:            #7f7f7f; }
 #vt100 .ansi9     { color:            #ff0000; }
 #vt100 .ansi10    { color:            #00ff00; }
-#vt100 .ansi11    { color:            #e8e8e0; }
+#vt100 .ansi11    { color:            #ffff00; }
 #vt100 .ansi12    { color:            #5c5cff; }
 #vt100 .ansi13    { color:            #ff00ff; }
 #vt100 .ansi14    { color:            #00ffff; }


### PR DESCRIPTION
ansi11, "bold yellow", used to be portrayed as #e8e8e0 (so light that most
people called it 'white'). While the color values for ansi colors aren't
standardized, this patch changes it to the more sensible #ffff00, that actually
looks like bright yellow, and is the color used to represent 'bold yellow' on
wikipedia's article on ANSI codes[1].

[1] https://en.wikipedia.org/w/index.php?title=ANSI_escape_code#8-bit