### PR TITLE
Update version number in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.57)
 
 dnl This is one of the locations where the authoritative version
 dnl  number is stored.  The other is in the debian/changelog.
-AC_INIT(shellinabox, 2.20, markus@shellinabox.com)
+AC_INIT(shellinabox, 2.21, markus@shellinabox.com)
 if test -e .git; then
 VCS_REVISION=" (revision `cd $srcdir && git log -1 --format=format:%h`)"
 else


### PR DESCRIPTION
Updates the version number in configure.ac to 2.21 which matches the
other authoritative version number in [debian/changelog](https://github.com/shellinabox/shellinabox/blob/4f0ecc31ac6f985e0dd3f5a52cbfc0e9251f6361/debian/changelog#L1). Without this
patch the `shellinboxd --version` command returns the previous version
number (2.20).

It would also be nice to have a tag and github release for this version as per https://github.com/shellinabox/shellinabox/issues/480.