### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+shellinabox (2.22) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since stretch:
+    + Build-Depends: Drop versioned constraint on debhelper.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 14 Jun 2021 05:34:07 -0000
+
 shellinabox (2.21) unstable; urgency=medium
 
   * Patched DoS vulnerability reported by Imre Rad.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: shellinabox
 Section: web
 Priority: optional
 Maintainer: Marc Singer <elf@debian.org>
-Build-Depends: debhelper (>= 9), autotools-dev, binutils,
+Build-Depends: debhelper, autotools-dev, binutils,
  libssl-dev, libpam0g-dev, zlib1g-dev, dh-autoreconf
 Standards-Version: 3.9.6
 Homepage: http://shellinabox.com


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/shellinabox/d1707554-7b4b-46fe-adc1-1ee2f298ccda.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/36/9b32fec708a7eabbbcf1813e284062393c980d.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/43/e26a9f2d3088c0ba13f05b3fd024b8aa0ede03.debug

No differences were encountered between the control files of package \*\*shellinabox\*\*
### Control files of package shellinabox-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-43e26a9f2d3088c0ba13f05b3fd024b8aa0ede03-] {+369b32fec708a7eabbbcf1813e284062393c980d+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/d1707554-7b4b-46fe-adc1-1ee2f298ccda/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/d1707554-7b4b-46fe-adc1-1ee2f298ccda/diffoscope)).
