### PR TITLE
Remove ambiguous option from ssh command line

### DIFF
--- a/shellinabox/service.c
+++ b/shellinabox/service.c
@@ -175,8 +175,8 @@ void initService(struct Service *service, const char *arg) {
           "-oHostbasedAuthentication=no -oIdentitiesOnly=yes "
           "-oKbdInteractiveAuthentication=yes -oPasswordAuthentication=yes "
           "-oPreferredAuthentications=keyboard-interactive,password "
-          "-oPubkeyAuthentication=no -oRhostsRSAAuthentication=no "
-          "-oRSAAuthentication=no -oStrictHostKeyChecking=no -oTunnel=no "
+          "-oPubkeyAuthentication=no "
+          "-oStrictHostKeyChecking=no -oTunnel=no "
           "-oUserKnownHostsFile=/dev/null -oVerifyHostKeyDNS=no "
 // beewoolie-2012.03.30: while it would be nice to disable this
 //          feature, we cannot be sure that it is available on the

--- a/shellinabox/service.c
+++ b/shellinabox/service.c
@@ -169,7 +169,7 @@ void initService(struct Service *service, const char *arg) {
     }
 
     service->cmdline                        = stringPrintf(NULL,
-      "ssh -a -e none -i /dev/null -x -oChallengeResponseAuthentication=no "
+      "ssh -a -e none -i /dev/null -x "
           "-oCheckHostIP=no -oClearAllForwardings=yes -oCompression=no "
           "-oControlMaster=no -oGSSAPIAuthentication=no "
           "-oHostbasedAuthentication=no -oIdentitiesOnly=yes "


### PR DESCRIPTION
ChallengeResponseAuthentication is a deprecated alias for KbdInteractiveAuthentication, both are used on SSH command line from shell in a box (one with =yes, one with =no), which disables keyboard-interactive auth with modern SSH releases (at least with OpenSSH >=8.9p1).

With "-oChallengeResponseAuthentication=no" keyboard-interactive auth is working again.

