### PR TITLE
Disable autocomplete

### DIFF
--- a/shellinabox/vt100.jspp
+++ b/shellinabox/vt100.jspp
@@ -916,7 +916,7 @@ VT100.prototype.initializeElements = function(container) {
                        '<div class="hidden">' +
                          '<div id="usercss"></div>' +
                          '<pre><div><span id="space"></span></div></pre>' +
-                         '<input type="text" id="input" autocorrect="off" autocapitalize="off" />' +
+                         '<input type="text" id="input" autocorrect="off" autocapitalize="off" autocomplete="off" />' +
                          '<input type="text" id="cliphelper" />' +
                          (typeof suppressAllAudio != 'undefined' &&
                           suppressAllAudio ? "" :


### PR DESCRIPTION
FIrefox has started popping up autocomplete suggestions when pressing the Up or Down arrow keys in shellinabox; this PR disables those.