### PR TITLE
configure: Define _GNU_SOURCE when probing for updwtmpx

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,7 +154,8 @@ if test "x$enable_utmp" != xno; then
               [updwtmp(0, 0);],
               [AC_DEFINE(HAVE_UPDWTMP, 1,
                          Define to 1 if you have support for updwtmp)])
-  AC_TRY_LINK([#include <utmpx.h>],
+  AC_TRY_LINK([#define _GNU_SOURCE
+	      #include <utmpx.h>],
               [updwtmpx(0, 0);],
               [AC_DEFINE(HAVE_UPDWTMPX, 1,
                          Define to 1 if you have support for updwtmpx)])


### PR DESCRIPTION
Otherwise, glibc's <utmpx.h> will not declare this function, and the configure probe fails with compilers which do not support implicit function declarations.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
