### PR TITLE
Fix value of _XOPEN_SOURCE for macOS

### DIFF
--- a/libhttp/url.c
+++ b/libhttp/url.c
@@ -45,7 +45,7 @@
 
 #include "config.h"
 
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 600
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
On macOS, `strdup` is only declared in <string.h> and `snprintf` is only declared in <stdio.h> if `_XOPEN_SOURCE` is undefined or is defined to `600` or greater.

Fixes #518